### PR TITLE
Suggested changes for pipelight & wine-silverlight AUR

### DIFF
--- a/pipelight/PKGBUILD
+++ b/pipelight/PKGBUILD
@@ -2,14 +2,15 @@
 
 pkgname='pipelight'
 pkgver=0.2.5
-pkgrel=2
+pkgrel=3
 epoch=1
 pkgdesc="A browser plugin which allows one to use windows only plugins inside Linux browser"
 url="https://launchpad.net/pipelight"
 arch=('i686' 'x86_64')
 license=('GPL2' 'LGPL2.1' 'MPL')
 
-depends=('wine-silverlight>=1.7.11-1' 'ttf-ms-fonts' 'wget')
+# wine-compholio is provided for example by wine-silverlight
+depends=('wine-compholio' 'ttf-ms-fonts' 'wget')
 if  [[ "$CARCH" == "x86_64" ]]; then
   depends+=('lib32-libsm' 'lib32-libgl')
 else
@@ -48,7 +49,7 @@ _srcdir=mmueller2012-pipelight-035090b504f5
 _prefix=/usr
 
 #change this if your wine-silverlight is installed elsewhere, or if you prefer a different wine directory
-_wine=/usr
+_wine=/opt/wine-compholio
 
 prepare() {
   pushd $_srcdir

--- a/pipelight/PKGBUILD
+++ b/pipelight/PKGBUILD
@@ -10,7 +10,7 @@ arch=('i686' 'x86_64')
 license=('GPL2' 'LGPL2.1' 'MPL')
 
 # wine-compholio is provided for example by wine-silverlight
-depends=('wine-compholio' 'ttf-ms-fonts' 'wget')
+depends=('wine-compholio' 'ttf-ms-fonts' 'wget' 'cabextract' 'unzip' 'gnupg')
 if  [[ "$CARCH" == "x86_64" ]]; then
   depends+=('lib32-libsm' 'lib32-libgl')
 else

--- a/pipelight/PKGBUILD
+++ b/pipelight/PKGBUILD
@@ -37,6 +37,7 @@ makedepends+=('cabextract' 'xz')
 #  "https://launchpad.net/pipelight/trunk/0.1/+download/pluginloader-prebuilt-v${pkgver%.*}-${pkgver##*.}.tar.gz")
 source=("https://bitbucket.org/mmueller2012/pipelight/get/v${pkgver}.tar.bz2"
   "http://repos.fds-team.de/pluginloader/v${pkgver}/pluginloader.tar.gz")
+noextract=("pluginloader.tar.gz")
 
 md5sums=('56f6ede3bafa9f2e5cf72bf087a98315'
          '029be1ca83633ffa87ef96e6fcf5f9c5')
@@ -53,35 +54,18 @@ _wine=/opt/wine-compholio
 
 prepare() {
   pushd $_srcdir
-
-  #The next two lines can't be used if you want to compile your own pluginloader.exe
   if [[ $_compilepluginloader == 0 ]]; then
-  #  sed -i '1s| src/windows||g' Makefile
-    sed -i '48d' Makefile
+    tar xvzf ../pluginloader.tar.gz
   fi
-
-  pushd src/windows
-  sed -i '2 a\ CXXFLAGS        := -static-libgcc -static-libstdc++ $(CXXFLAGS)' Makefile
-  popd
-  pushd share/configs/
-  sed -i '50s|^gccRun|#gccRun|g' pipelight-*
-  sed -i "118s|wine-silverlight/install-dependency|wine-silverlight/install-dependency-pipelight|g" pipelight-*
-
-  #in case you want to use 64bit wine, you would need this
-  #if [[ "$CARCH" == "x86_64" ]]; then
-  #  sed -i 's|Files|Files (x86)|g' pipelight
-  #fi
-
-  popd
   popd
 }
 
 build() {
   pushd $_srcdir
   if [[ $_compilepluginloader == 0 ]]; then
-    ./configure --prefix=$_prefix --wine-path=$_wine/bin/wine --win32-prebuilt
+    ./configure --prefix=$_prefix --wine-path=$_wine/bin/wine --gcc-runtime-dlls="" --win32-prebuilt
   else
-    ./configure --prefix=$_prefix --wine-path=$_wine/bin/wine --win32-static
+    ./configure --prefix=$_prefix --wine-path=$_wine/bin/wine --gcc-runtime-dlls="" --win32-static
   fi
   make
   popd
@@ -90,11 +74,6 @@ build() {
 package() {
   make -C $_srcdir PREFIX=$_prefix DESTDIR=$pkgdir install
 
-  if [[ $_compilepluginloader  == 0 ]]; then
-#   As of v0.2.1, pluginloader is always statically compiled, no longer needed
-#   install -Dm644 l*.dll ${pkgdir}/$_prefix/share/pipelight/.
-    install -Dm644 src/windows/pluginloader.exe ${pkgdir}/$_prefix/share/pipelight/.
-  fi
 # All plugin creation has now been moved to pipelight.install
 
 # fix man page flags

--- a/wine-silverlight/PKGBUILD
+++ b/wine-silverlight/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=wine-silverlight
 pkgver=1.7.14
-pkgrel=1
+pkgrel=2
 pkgdesc="WINE patched with Microsoft Silverlight and Netflix compatibility."
 url="http://www.winehq.com"
 license=('LGPL2.1')
@@ -291,19 +291,18 @@ _upname="wine-${pkgver}"
 if [[ $customprefix != 1 ]]; then
   _prefix="usr"
   _sysconf="etc"
-  conflicts=('wine')
-  provides=('wine=${pkgver}')
+  conflicts=('wine' 'wine-compholio')
+  provides=('wine=${pkgver}' 'wine-compholio=${pkgver}')
 else
   # change _prefix if you don't want to use the default custom prefix of /opt/wine-silverlight
   _prefix="opt/$pkgname"
   _sysconf="$_prefix/etc"
+  conflicts=('wine-compholio')
+  provides=('wine-compholio=${pkgver}')
 fi
 
 build() {
   cd "$srcdir"
-
-
-
 
   # ncurses fix
   sed -i 's|libncurses|libncursesw|g' "$srcdir/$_upname/configure"
@@ -457,6 +456,14 @@ if [[ $customprefix != 1 ]]; then
   install -m644 "$srcdir/30-win32-aliases.conf" "$pkgdir/etc/fonts/conf.avail"
   ln -s ../conf.avail/30-win32-aliases.conf "$pkgdir/etc/fonts/conf.d/30-win32-aliases.conf"
 fi
+
+  # Provide symlinks in /opt/wine-compholio/bin
+  if [[ "$_prefix" != "opt/wine-compholio" ]]; then
+    mkdir -p "$pkgdir/opt/wine-compholio/bin"
+    for _file in $(ls "$pkgdir/$_prefix/bin"); do \
+      ln -s "$_prefix/bin/$_file" "$pkgdir/opt/wine-compholio/bin/$_file"; \
+    done
+  fi
 
 }
 # vim:set ts=2 sw=2 tw=0 et:

--- a/wine-silverlight/PKGBUILD
+++ b/wine-silverlight/PKGBUILD
@@ -304,10 +304,6 @@ fi
 build() {
   cd "$srcdir"
 
-  # ncurses fix
-  sed -i 's|libncurses|libncursesw|g' "$srcdir/$_upname/configure"
-  sed -i 's|lncurses|lncursesw|g' "$srcdir/$_upname/configure" 
-
   # Get rid of old build dirs
   rm -rf $pkgname-{32,64}-build
   mkdir $pkgname-32-build
@@ -389,6 +385,10 @@ build() {
 
   ./tools/make_requests
   autoreconf
+
+  # ncurses fix
+  sed -i 's|libncurses|libncursesw|g' "$srcdir/$_upname/configure"
+  sed -i 's|lncurses|lncursesw|g' "$srcdir/$_upname/configure" 
 
   cd "$srcdir"
 


### PR DESCRIPTION
WARNING: A lot of the changes have not been tested yet. If you agree that the changes are useful it would be nice to do some testing yourself (= at least confirm once that it still compiles well). More details about the changes are listed below.

Main reason for this patchset: All the different pipelight packages (AUR:pipelight, AUR:pipelight-git, repo:pipelight) and wine packages (AUR:wine-silverlight, AUR:wine-compholio-bin, repo:wine-compholio) make it very difficult for users to mix the versions. Nearly every version uses a different path and has different dependencies. My goal is to "unify" the packages a bit, such that users can use for example use our wine-compholio version combined with pipelight from AUR, or even with pipelight-git if they want to try out new features.

This patchset includes the following changes:
#1) wine-silverlight installs some additional symlinks to /opt/wine-compholio/bin/*. This is sufficient for Pipelight, and makes it possible to compile Pipelight with the upstream /opt/wine-compholio/ wine path. Moreover the wine version now provides "wine-compholio".
#2) Change pipelight dependency to "wine-compholio".
#3) Fix a bug in the wine-silverlight PKGBUILD. The ncurses fix has no effect if the ./configure script is overwritten later by autoreconf.
#4) Your pipelight package was still missing some dependencies. Since we got a bug report recently for this issue, and I've already fixed it in our repo, it would be nice if you could fix this, too.
#5) Some code in the PKGBUILD script of Pipelight looks outdated. I've cleaned this up a bit. For a detailed list of all the changes take a look at the commit message.

If there is anything else I have to fix before merging, please report back and I'll take a look at it.

Regards,
Sebastian
